### PR TITLE
ft-uc11: best verkochte producten toegevoegd

### DIFF
--- a/Grocery.App/Views/BestSellingProductsView.xaml
+++ b/Grocery.App/Views/BestSellingProductsView.xaml
@@ -6,9 +6,13 @@
              x:Class="Grocery.App.Views.BestSellingProductsView"
              x:DataType="vm:BestSellingProductsViewModel"
              Title="BestSellingProductsView">
+
     <Shell.TitleView>
         <Grid>
-            <Label Text="Best verkochte producten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
+            <Label Text="Best verkochte producten"
+                   FontSize="Large"
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
 
@@ -17,6 +21,8 @@
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
             </CollectionView.ItemsLayout>
+
+            <!-- Header -->
             <CollectionView.Header>
                 <Grid>
                     <Grid.ColumnDefinitions>
@@ -25,9 +31,15 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <!-- PLaats hier de header velden voor de tabel-->
+
+                    <Label Grid.Column="0" Text="#" FontAttributes="Bold" HorizontalOptions="Center"/>
+                    <Label Grid.Column="1" Text="Product" FontAttributes="Bold"/>
+                    <Label Grid.Column="2" Text="Aantal verkocht" FontAttributes="Bold" HorizontalOptions="Center"/>
+                    <Label Grid.Column="3" Text="Voorraad" FontAttributes="Bold" HorizontalOptions="Center"/>
                 </Grid>
             </CollectionView.Header>
+
+            <!-- Rows -->
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="m:BestSellingProducts">
                     <Grid>
@@ -37,7 +49,11 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <!-- PLaats hier de datavelden voor de tabel-->
+
+                        <Label Grid.Column="0" Text="{Binding Ranking}" HorizontalOptions="Center"/>
+                        <Label Grid.Column="1" Text="{Binding Name}"/>
+                        <Label Grid.Column="2" Text="{Binding NrOfSells}" HorizontalOptions="Center"/>
+                        <Label Grid.Column="3" Text="{Binding Stock}" HorizontalOptions="Center"/>
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/Grocery.Core/Services/GroceryListItemsService.cs
+++ b/Grocery.Core/Services/GroceryListItemsService.cs
@@ -51,8 +51,38 @@ namespace Grocery.Core.Services
 
         public List<BestSellingProducts> GetBestSellingProducts(int topX = 5)
         {
-            throw new NotImplementedException();
+            var allItems = _groceriesRepository.GetAll();
+
+            var grouped = allItems
+                .GroupBy(i => i.ProductId)
+                .Select(g =>
+                {
+                    var product = _productRepository.Get(g.Key);
+                    return new
+                    {
+                        ProductId = g.Key,
+                        ProductName = product?.Name ?? "Onbekend product",
+                        Stock = product?.Stock ?? 0,
+                        NrOfSells = g.Sum(x => x.Amount)
+                    };
+                })
+                .OrderByDescending(x => x.NrOfSells)
+                .Take(topX)
+                .ToList();
+
+            var result = grouped
+                .Select((x, index) => new BestSellingProducts(
+                    x.ProductId,
+                    x.ProductName,
+                    x.Stock,
+                    x.NrOfSells,
+                    index + 1 // ranking
+                ))
+                .ToList();
+
+            return result;
         }
+
 
         private void FillService(List<GroceryListItem> groceryListItems)
         {


### PR DESCRIPTION
### UC11 – Meest verkochte producten

- Service: `GetBestSellingProducts` toegevoegd (som van Amount per product)
- View (XAML): tabel met ranking, productnaam, aantal verkocht en voorraad
- Data bindt correct via `BestSellingProducts` model
<img width="1470" height="956" alt="Scherm­afbeelding 2025-09-30 om 18 18 50" src="https://github.com/user-attachments/assets/a14d75fa-c4ec-4930-92a4-53ce80ad9d30" />
