### PR TITLE
Feature/uc13 klanten tonen product

### DIFF
--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -4,29 +4,64 @@ using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
 using System.Collections.ObjectModel;
 
-
 namespace Grocery.App.ViewModels
 {
+    /// <summary>
+    /// ViewModel dat de aankopen per product toont. 
+    /// Koppelt producten aan de klanten en boodschappenlijsten waarin ze voorkomen.
+    /// </summary>
     public partial class BoughtProductsViewModel : BaseViewModel
     {
         private readonly IBoughtProductsService _boughtProductsService;
-
+        
         [ObservableProperty]
         Product selectedProduct;
         public ObservableCollection<BoughtProducts> BoughtProductsList { get; set; } = [];
         public ObservableCollection<Product> Products { get; set; }
 
+        /// <summary>
+        /// Constructor, zet de services en vult meteen de lijst met beschikbare producten.
+        /// </summary>
         public BoughtProductsViewModel(IBoughtProductsService boughtProductsService, IProductService productService)
         {
             _boughtProductsService = boughtProductsService;
             Products = new(productService.GetAll());
         }
-
+        
+        /// <summary>
+        /// Callback die afgaat zodra de waarde van <see cref="SelectedProduct"/> verandert.
+        /// Leegt eerst de huidige lijst en vult deze daarna met de aankopen van het gekozen product.
+        /// </summary>
+        /// <param name="oldValue">Product dat eerder geselecteerd was</param>
+        /// <param name="newValue">Het product dat nu geselecteerd is</param>
         partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
         {
-            //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
+            if (newValue != null)
+            {
+                System.Diagnostics.Debug.WriteLine($"Nieuw product geselecteerd: {newValue.Name} (Id: {newValue.Id})");
+                
+                BoughtProductsList.Clear();
+
+                // Nieuwe aankopen ophalen via de service
+                var boughtProducts = _boughtProductsService.Get(newValue.Id);
+                System.Diagnostics.Debug.WriteLine($"Aantal resultaten opgehaald: {boughtProducts.Count}");
+                
+                // Toevoegen van elk resultaat aan de observable collectie
+                foreach (var item in boughtProducts)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Resultaat toegevoegd: {item.Client.Name} - {item.GroceryList.Name}");
+                    BoughtProductsList.Add(item);
+                }
+                
+                System.Diagnostics.Debug.WriteLine($"Huidige aantal items in BoughtProductsList: {BoughtProductsList.Count}");
+            }
         }
 
+        /// <summary>
+        /// Command waarmee vanuit code-behind of de UI een product gekozen kan worden.
+        /// Het instellen van <see cref="SelectedProduct"/> triggert automatisch de update van de lijst.
+        /// </summary>
+        /// <param name="product">Het product dat geselecteerd moet worden</param>
         [RelayCommand]
         public void NewSelectedProduct(Product product)
         {

--- a/Grocery.App/ViewModels/GroceryListViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListViewModel.cs
@@ -10,11 +10,13 @@ namespace Grocery.App.ViewModels
     {
         public ObservableCollection<GroceryList> GroceryLists { get; set; }
         private readonly IGroceryListService _groceryListService;
+        private readonly GlobalViewModel _globalViewModel;
 
-        public GroceryListViewModel(IGroceryListService groceryListService) 
+        public GroceryListViewModel(IGroceryListService groceryListService, GlobalViewModel globalViewModel) 
         {
             Title = "Boodschappenlijst";
             _groceryListService = groceryListService;
+            _globalViewModel = globalViewModel;
             GroceryLists = new(_groceryListService.GetAll());
         }
 
@@ -24,6 +26,22 @@ namespace Grocery.App.ViewModels
             Dictionary<string, object> paramater = new() { { nameof(GroceryList), groceryList } };
             await Shell.Current.GoToAsync($"{nameof(Views.GroceryListItemsView)}?Titel={groceryList.Name}", true, paramater);
         }
+        
+        [RelayCommand]
+        public async Task ShowBoughtProducts()
+        {
+            /// <summary>
+            /// Opent het scherm waarin alle aankopen per product worden getoond.
+            /// Alleen gebruikers met de rol Admin hebben toegang tot deze functionaliteit.
+            /// Als de huidige client geen admin is, gebeurt er niets.
+            /// </summary>
+            if (_globalViewModel.Client != null && _globalViewModel.Client.Role == Role.Admin)
+            {
+                await Shell.Current.GoToAsync(nameof(Views.BoughtProductsView));
+            }
+        }
+
+        
         public override void OnAppearing()
         {
             base.OnAppearing();

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -16,11 +16,12 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title="Klik op onderstaand pijltje om een product te selecteren:"
-        ItemsSource="{Binding Products}"
-        SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
-        SelectedIndexChanged="Picker_SelectedIndexChanged"
-        BackgroundColor="{StaticResource Primary}"
-            TextColor="{StaticResource Secondary}">
+                ItemsSource="{Binding Products}"
+                ItemDisplayBinding="{Binding Name}"
+                SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
+                SelectedIndexChanged="Picker_SelectedIndexChanged"
+                BackgroundColor="{StaticResource Primary}"
+                TextColor="{StaticResource Secondary}">
         </Picker>
         <Border Grid.Row="1" Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <CollectionView ItemsSource="{Binding BoughtProductsList}" Margin="5" HorizontalOptions="End" SelectionMode="Single">
@@ -34,7 +35,15 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <!-- Toon hier de naam van de Client naam van de boodschappenlijst -->
+                            <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Text="{Binding Client.Name}" FontSize="16" />
+                            <Label Grid.Column="1" Text="{Binding GroceryList.Name}" FontSize="16" HorizontalOptions="End" />
+                        </Grid>
+
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -11,6 +11,12 @@
             <Label Text="Boodschappenlijsten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
+    
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Admin Menu" Command="{Binding ShowBoughtProductsCommand}" />
+    </ContentPage.ToolbarItems>
+
+
 
     <Border Stroke="#C49B33"
         StrokeThickness="4"

--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -13,7 +13,7 @@ namespace Grocery.Core.Data.Repositories
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
                 new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
-                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=")
+                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=") {Role = Role.Admin}
             ];
         }
 

--- a/Grocery.Core/Models/Client.cs
+++ b/Grocery.Core/Models/Client.cs
@@ -5,6 +5,7 @@ namespace Grocery.Core.Models
     {
         public string EmailAddress { get; set; }
         public string Password { get; set; }
+        public Role Role { get; set; } = Role.None;
         public Client(int id, string name, string emailAddress, string password) : base(id, name)
         {
             EmailAddress=emailAddress;

--- a/Grocery.Core/Models/Role.cs
+++ b/Grocery.Core/Models/Role.cs
@@ -1,0 +1,18 @@
+namespace Grocery.Core.Models
+{
+    /// <summary>
+    /// Deze enum stelt de mogelijke rollen van een client (gebruiker) in de applicatie voor.
+    /// </summary>
+    public enum Role
+    {
+        /// <summary>
+        /// Geen rol toegewezen (standaardwaarde).
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Admin-rol: heeft extra rechten en kan beheertaken uitvoeren.
+        /// </summary>
+        Admin = 1
+    }
+}

--- a/Grocery.Core/Services/BoughtProductsService.cs
+++ b/Grocery.Core/Services/BoughtProductsService.cs
@@ -1,26 +1,95 @@
-﻿
-using Grocery.Core.Interfaces.Repositories;
+﻿using Grocery.Core.Interfaces.Repositories;
 using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Grocery.Core.Services
 {
+    /// <summary>
+    /// Service die alle aankopen (Client, GroceryList, Product) teruggeeft
+    /// waarin een specifiek product voorkomt.
+    /// </summary>
     public class BoughtProductsService : IBoughtProductsService
     {
-        private readonly IGroceryListItemsRepository _groceryListItemsRepository;
-        private readonly IClientRepository _clientRepository;
-        private readonly IProductRepository _productRepository;
-        private readonly IGroceryListRepository _groceryListRepository;
-        public BoughtProductsService(IGroceryListItemsRepository groceryListItemsRepository, IGroceryListRepository groceryListRepository, IClientRepository clientRepository, IProductRepository productRepository)
+        // Repositories die nodig zijn om data op te halen
+        private readonly IGroceryListItemsRepository _listItemsRepo;
+        private readonly IGroceryListRepository _listsRepo;
+        private readonly IClientRepository _clientsRepo;
+        private readonly IProductRepository _productsRepo;
+
+        /// <summary>
+        /// Constructor: injecteert de vereiste repositories.
+        /// </summary>
+        public BoughtProductsService(
+            IGroceryListItemsRepository listItemsRepo,
+            IGroceryListRepository listsRepo,
+            IClientRepository clientsRepo,
+            IProductRepository productsRepo)
         {
-            _groceryListItemsRepository=groceryListItemsRepository;
-            _groceryListRepository=groceryListRepository;
-            _clientRepository=clientRepository;
-            _productRepository=productRepository;
+            _listItemsRepo = listItemsRepo;
+            _listsRepo = listsRepo;
+            _clientsRepo = clientsRepo;
+            _productsRepo = productsRepo;
         }
+
+        /// <summary>
+        /// Haalt alle aankopen voor een bepaald productId op.
+        /// Combineert data uit GroceryListItems, GroceryLists, Clients en Products.
+        /// </summary>
+        /// <param name="productId">Het ID van het gewenste product (null of <= 0 levert lege lijst op).</param>
+        /// <returns>Lijst met BoughtProducts, elk bevat Client, GroceryList en Product.</returns>
         public List<BoughtProducts> Get(int? productId)
         {
-            throw new NotImplementedException();
+            // Guard: als productId niet geldig is, meteen een lege lijst teruggeven
+            if (productId is null || productId <= 0)
+            {
+                Debug.WriteLine($"[BoughtProductsService] Ongeldig productId: {(productId is null ? "null" : productId.Value.ToString())}");
+                return new List<BoughtProducts>();
+            }
+
+            Debug.WriteLine($"[BoughtProductsService] Ophalen aankopen voor productId={productId}");
+
+            //  Alle GroceryListItems ophalen en filteren op dit productId
+            var itemsForProduct = _listItemsRepo
+                .GetAll()
+                .Where(i => i.ProductId == productId.Value)
+                .ToList();
+
+            Debug.WriteLine($"[BoughtProductsService] Items met productId={productId}: {itemsForProduct.Count}");
+
+            // Resultaatlijst vullen door Client + List + Product
+            var results = new List<BoughtProducts>();
+
+            foreach (var item in itemsForProduct)
+            {
+                // Haal bijbehorende boodschappenlijst op
+                var list = _listsRepo.Get(item.GroceryListId);
+                if (list is null) continue;
+
+                // Haal de client van deze boodschappenlijst op
+                var client = _clientsRepo.Get(list.ClientId);
+                if (client is null) continue;
+
+                // Haal het product op
+                var product = _productsRepo.Get(item.ProductId);
+                if (product is null) continue;
+
+                Debug.WriteLine($"[BoughtProductsService] Match gevonden: Client={client.Name}, List={list.Name}, Product={product.Name}, Amount={item.Amount}");
+
+                // Voeg samen in BoughtProducts-model
+                results.Add(new BoughtProducts(client, list, product));
+            }
+
+            // Sorteer de resultaten alfabetisch op Client-naam en List-naam
+            results = results
+                .OrderBy(r => r.Client.Name)
+                .ThenBy(r => r.GroceryList.Name)
+                .ToList();
+
+            Debug.WriteLine($"[BoughtProductsService] Totaal matches: {results.Count}");
+            return results;
         }
     }
 }


### PR DESCRIPTION
Pull: nieuwe feature en updates voor UC13 

## UC13 – Klanten tonen per product

Deze use case laat zien welke klanten een bepaald product hebben gekocht.

### Uitwerking
- Maak een **enum `Role`** met de waarden `None` en `Admin`.
- Voeg in de **Client-class** een property `Role` toe van het type `Role`.  
  - Standaardwaarde = `Role.None`.
- In de **ClientRepository** koppel je `Role.Admin` aan **user3** (de admin-gebruiker).
- Werk in de **BoughtProductsService** de methode `Get(productId)` uit.  
  - Deze geeft alle klanten terug die het gekozen product hebben gekocht, inclusief **Client**, **GroceryList** en **Product**.
- In de **BoughtProductsView** moet de **naam van de Client** en de **naam van de Boodschappenlijst** zichtbaar zijn in een `CollectionView`.
- In de **BoughtProductsViewModel** werk je `OnSelectedProductChanged` uit zodat bij een ander product de lijst correct wordt bijgewerkt.
- In de **GroceryListViewModel** maak je de methode `ShowBoughtProducts()`.  
  - Alleen wanneer de ingelogde client de rol **Admin** heeft, wordt genavigeerd naar `BoughtProductsView`.  
  - Anders gebeurt er niets.
- In de **GroceryListView** voeg je een `ToolbarItem` toe met:  
  - **Text** gebonden aan `Client.Name`.  
  - **Command** gebonden aan `ShowBoughtProducts`.  
